### PR TITLE
Fix magazine project icon rendering

### DIFF
--- a/templates/projects.html
+++ b/templates/projects.html
@@ -105,7 +105,7 @@
             </header>
             <div class="portfolio-grid">
                 <article class="project-card">
-                    <div class="project-icon" aria-hidden="true">�</div>
+                    <div class="project-icon" aria-hidden="true">📘</div>
                     <h3>Inside Imaging Magazine</h3>
                     <p>Monthly deep-dives on radiology storytelling, AI adoption, and patient-centered education.</p>
                     <a class="project-link" href="{{ url_for('magazine') }}">Browse magazine archives →</a>


### PR DESCRIPTION
## Summary
- replace the placeholder glyph in the Inside Imaging Magazine project card with a book emoji so the icon renders reliably across browsers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fb55eb508c8327a3dfbb9f68765242