### PR TITLE
Fix PDF download, UI cleanup, and auth button changes

### DIFF
--- a/static/auth.css
+++ b/static/auth.css
@@ -162,6 +162,8 @@
 
 .social-btn {
     flex: 1;
+    min-width: 0;
+    box-sizing: border-box;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -175,6 +177,8 @@
     font-weight: 500;
     cursor: pointer;
     transition: all 0.2s ease;
+    text-decoration: none;
+    line-height: 1;
 }
 
 .social-btn:hover {

--- a/templates/base.html
+++ b/templates/base.html
@@ -229,13 +229,13 @@
   <!-- theme switcher -->
   <label class="theme-switch fixed-switch" aria-label="Toggle theme">
     <span class="theme-row">
-      <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+      <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none"
           stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
         </svg></span>
       <input id="theme-toggle" class="theme-switch-input" type="checkbox" role="switch" aria-checked="false">
       <span class="theme-switch-track" aria-hidden="true"></span>
-      <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+      <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none"
           stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <circle cx="12" cy="12" r="5"></circle>
           <line x1="12" y1="1" x2="12" y2="3"></line>

--- a/templates/blogs.html
+++ b/templates/blogs.html
@@ -168,6 +168,7 @@
       </section>
       {% endif %}
 
+      {# HIDDEN: Publish Your Perspective section — stashed, uncomment to restore
       <section class="blog-submit">
         <h2>Publish Your Perspective</h2>
         <p>We feature practical guidance, communication strategies, and patient-centered workflows. Submissions are
@@ -178,6 +179,7 @@
         <p>Email <strong>editor@insideimaging.example</strong> to submit a draft.</p>
         {% endif %}
       </section>
+      #}
     </main>
 
     {% include '_footer.html' %}

--- a/templates/blogs.html
+++ b/templates/blogs.html
@@ -36,19 +36,18 @@
         <a href="{{ url_for('dashboard') }}">Dashboard</a>
         <a href="{{ url_for('report_status') }}">Statistics</a>
         <a href="{{ url_for('team') }}">Our Team</a>
-        <a href="{{ url_for('payment') }}">Payment</a>
         <a href="{{ url_for('help_page') }}">Help</a>
       </nav>
       <div class="nav-auth">
         <label class="theme-switch" aria-label="Toggle theme">
           <span class="theme-row">
-            <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+            <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none"
                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
               </svg></span>
             <input id="theme-toggle" class="theme-switch-input" type="checkbox" role="switch" aria-checked="false">
             <span class="theme-switch-track" aria-hidden="true"></span>
-            <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+            <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none"
                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <circle cx="12" cy="12" r="5"></circle>
                 <line x1="12" y1="1" x2="12" y2="3"></line>

--- a/templates/feedback_admin.html
+++ b/templates/feedback_admin.html
@@ -91,7 +91,7 @@
                 <!-- Slider toggle -->
                 <label class="theme-switch" aria-label="Toggle theme">
                     <span class="theme-row">
-                        <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24"
+                        <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24"
                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                 stroke-linejoin="round">
                                 <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
@@ -99,7 +99,7 @@
                         <input id="theme-toggle" class="theme-switch-input" type="checkbox" role="switch"
                             aria-checked="false">
                         <span class="theme-switch-track" aria-hidden="true"></span>
-                        <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24"
+                        <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24"
                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                 stroke-linejoin="round">
                                 <circle cx="12" cy="12" r="5"></circle>

--- a/templates/help.html
+++ b/templates/help.html
@@ -39,14 +39,13 @@
                 <a href="{{ url_for('dashboard') }}">Dashboard</a>
                 <a href="{{ url_for('report_status') }}">Statistics</a>
                 <a href="{{ url_for('team') }}">Our Team</a>
-                <a href="{{ url_for('payment') }}">Payment</a>
                 <a href="{{ url_for('help_page') }}" class="active">Help</a>
             </nav>
             <div class="nav-auth">
                 <!-- Slider toggle (replaces the old button) -->
                 <label class="theme-switch" aria-label="Toggle theme">
                     <span class="theme-row">
-                        <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24"
+                        <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24"
                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                 stroke-linejoin="round">
                                 <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
@@ -54,7 +53,7 @@
                         <input id="theme-toggle" class="theme-switch-input" type="checkbox" role="switch"
                             aria-checked="false">
                         <span class="theme-switch-track" aria-hidden="true"></span>
-                        <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24"
+                        <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24"
                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                 stroke-linejoin="round">
                                 <circle cx="12" cy="12" r="5"></circle>

--- a/templates/index.html
+++ b/templates/index.html
@@ -150,7 +150,6 @@
         <a href="{{ url_for('dashboard') }}" class="active">Dashboard</a>
         <a href="{{ url_for('report_status') }}">Statistics</a>
         <a href="{{ url_for('team') }}">Our Team</a>
-        <a href="{{ url_for('payment') }}">Payment</a>
         <a href="{{ url_for('help_page') }}">Help</a>
       </nav>
       <div class="nav-auth">

--- a/templates/language.html
+++ b/templates/language.html
@@ -36,19 +36,18 @@
         <a href="{{ url_for('dashboard') }}">Dashboard</a>
         <a href="{{ url_for('report_status') }}">Statistics</a>
         <a href="{{ url_for('team') }}">Our Team</a>
-        <a href="{{ url_for('payment') }}">Payment</a>
         <a href="{{ url_for('help_page') }}">Help</a>
       </nav>
       <div class="nav-auth">
         <label class="theme-switch" aria-label="Toggle theme">
           <span class="theme-row">
-            <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+            <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none"
                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
               </svg></span>
             <input id="theme-toggle" class="theme-switch-input" type="checkbox" role="switch" aria-checked="false">
             <span class="theme-switch-track" aria-hidden="true"></span>
-            <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+            <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none"
                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <circle cx="12" cy="12" r="5"></circle>
                 <line x1="12" y1="1" x2="12" y2="3"></line>

--- a/templates/login.html
+++ b/templates/login.html
@@ -120,6 +120,7 @@
                             <span class="btn-gradient-blur"></span>
                         </button>
 
+                        {# HIDDEN: OR divider + social login buttons — stashed, uncomment to restore
                         <div class="auth-divider">
                             <span>OR</span>
                         </div>
@@ -146,6 +147,7 @@
                                 <span>Google</span>
                             </a>
                         </div>
+                        #}
                     </form>
 
                     <p class="auth-footer">Don't have an account? <a href="{{ url_for('signup') }}">Sign Up</a></p>

--- a/templates/login.html
+++ b/templates/login.html
@@ -37,14 +37,13 @@
                 <a href="{{ url_for('dashboard') }}">Dashboard</a>
                 <a href="{{ url_for('report_status') }}">Statistics</a>
                 <a href="{{ url_for('team') }}">Our Team</a>
-                <a href="{{ url_for('payment') }}">Payment</a>
                 <a href="{{ url_for('help_page') }}">Help</a>
             </nav>
             <div class="nav-auth">
                 <!-- Slider toggle -->
                 <label class="theme-switch" aria-label="Toggle theme">
                     <span class="theme-row">
-                        <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24"
+                        <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24"
                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                 stroke-linejoin="round">
                                 <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
@@ -52,7 +51,7 @@
                         <input id="theme-toggle" class="theme-switch-input" type="checkbox" role="switch"
                             aria-checked="false">
                         <span class="theme-switch-track" aria-hidden="true"></span>
-                        <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24"
+                        <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24"
                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                 stroke-linejoin="round">
                                 <circle cx="12" cy="12" r="5"></circle>

--- a/templates/payment.html
+++ b/templates/payment.html
@@ -37,20 +37,19 @@
         <a href="{{ url_for('dashboard') }}">Dashboard</a>
         <a href="{{ url_for('report_status') }}">Statistics</a>
         <a href="{{ url_for('team') }}">Our Team</a>
-        <a href="{{ url_for('payment') }}" class="active">Payment</a>
         <a href="{{ url_for('help_page') }}">Help</a>
       </nav>
       <div class="nav-auth">
         <!-- Slider toggle -->
         <label class="theme-switch" aria-label="Toggle theme">
           <span class="theme-row">
-            <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+            <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none"
                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
               </svg></span>
             <input id="theme-toggle" class="theme-switch-input" type="checkbox" role="switch" aria-checked="false">
             <span class="theme-switch-track" aria-hidden="true"></span>
-            <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+            <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none"
                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <circle cx="12" cy="12" r="5"></circle>
                 <line x1="12" y1="1" x2="12" y2="3"></line>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -74,14 +74,13 @@
                 <a href="{{ url_for('dashboard') }}">Dashboard</a>
                 <a href="{{ url_for('report_status') }}">Statistics</a>
                 <a href="{{ url_for('team') }}">Our Team</a>
-                <a href="{{ url_for('payment') }}">Payment</a>
                 <a href="{{ url_for('help_page') }}">Help</a>
             </nav>
             <div class="nav-auth">
                 <!-- Slider toggle -->
                 <label class="theme-switch" aria-label="Toggle theme">
                     <span class="theme-row">
-                        <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24"
+                        <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24"
                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                 stroke-linejoin="round">
                                 <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
@@ -89,7 +88,7 @@
                         <input id="theme-toggle" class="theme-switch-input" type="checkbox" role="switch"
                             aria-checked="false">
                         <span class="theme-switch-track" aria-hidden="true"></span>
-                        <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24"
+                        <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24"
                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                 stroke-linejoin="round">
                                 <circle cx="12" cy="12" r="5"></circle>

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -292,6 +292,7 @@
                 </div>
                 {% endif %}
 
+                {# HIDDEN: Publish Your Perspective section — stashed, uncomment to restore
                 <div class="blog-submit">
                     <h3>Publish Your Perspective</h3>
                     <p>We feature communication strategies, workflow redesigns, and patient-centered playbooks.
@@ -302,6 +303,7 @@
                     <p>Email <strong>editor@insideimaging.example</strong> to submit a draft.</p>
                     {% endif %}
                 </div>
+                #}
             </section>
         </main>
 

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -58,7 +58,6 @@
                 <a href="{{ url_for('dashboard') }}">Dashboard</a>
                 <a href="{{ url_for('report_status') }}">Statistics</a>
                 <a href="{{ url_for('team') }}">Our Team</a>
-                <a href="{{ url_for('payment') }}">Payment</a>
                 <a href="{{ url_for('help_page') }}">Help</a>
             </nav>
             <div class="nav-auth">

--- a/templates/report_status.html
+++ b/templates/report_status.html
@@ -40,7 +40,6 @@
         <a href="{{ url_for('dashboard') }}">Dashboard</a>
         <a href="{{ url_for('report_status') }}" class="active">Statistics</a>
         <a href="{{ url_for('team') }}">Our Team</a>
-        <a href="{{ url_for('payment') }}">Payment</a>
         <a href="{{ url_for('help_page') }}">Help</a>
       </nav>
       <div class="nav-auth">

--- a/templates/report_status.html
+++ b/templates/report_status.html
@@ -46,13 +46,13 @@
       <div class="nav-auth">
         <label class="theme-switch" aria-label="Toggle theme">
           <span class="theme-row">
-            <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+            <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none"
                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
               </svg></span>
             <input id="theme-toggle" class="theme-switch-input" type="checkbox" role="switch" aria-checked="false">
             <span class="theme-switch-track" aria-hidden="true"></span>
-            <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+            <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none"
                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <circle cx="12" cy="12" r="5"></circle>
                 <line x1="12" y1="1" x2="12" y2="3"></line>

--- a/templates/result.html
+++ b/templates/result.html
@@ -93,6 +93,14 @@
       color: var(--text);
     }
 
+    /* Uniform heading colors: all section headings mint, body text white */
+    h1,
+    h2,
+    h3,
+    h4 {
+      color: var(--mint);
+    }
+
     a {
       color: var(--link);
     }
@@ -262,19 +270,18 @@
         <a href="{{ url_for('dashboard') }}">Dashboard</a>
         <a href="{{ url_for('report_status') }}">Statistics</a>
         <a href="{{ url_for('team') }}">Our Team</a>
-        <a href="{{ url_for('payment') }}">Payment</a>
         <a href="{{ url_for('help_page') }}">Help</a>
       </nav>
       <div class="nav-auth">
         <label class="theme-switch" aria-label="Toggle theme">
           <span class="theme-row">
-            <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+            <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none"
                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
               </svg></span>
             <input id="theme-toggle" class="theme-switch-input" type="checkbox" role="switch" aria-checked="false">
             <span class="theme-switch-track" aria-hidden="true"></span>
-            <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+            <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none"
                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <circle cx="12" cy="12" r="5"></circle>
                 <line x1="12" y1="1" x2="12" y2="3"></line>

--- a/templates/result.html
+++ b/templates/result.html
@@ -93,6 +93,12 @@
       color: var(--text);
     }
 
+    /* Override dashboard.css .content p { color: var(--muted) } so all
+       report paragraph text is white, not gray */
+    .content p {
+      color: var(--text);
+    }
+
     /* Uniform heading colors: all section headings mint, body text white */
     h1,
     h2,

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -37,14 +37,13 @@
                 <a href="{{ url_for('dashboard') }}">Dashboard</a>
                 <a href="{{ url_for('report_status') }}">Statistics</a>
                 <a href="{{ url_for('team') }}">Our Team</a>
-                <a href="{{ url_for('payment') }}">Payment</a>
                 <a href="{{ url_for('help_page') }}">Help</a>
             </nav>
             <div class="nav-auth">
                 <!-- Slider toggle -->
                 <label class="theme-switch" aria-label="Toggle theme">
                     <span class="theme-row">
-                        <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24"
+                        <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24"
                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                 stroke-linejoin="round">
                                 <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
@@ -52,7 +51,7 @@
                         <input id="theme-toggle" class="theme-switch-input" type="checkbox" role="switch"
                             aria-checked="false">
                         <span class="theme-switch-track" aria-hidden="true"></span>
-                        <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24"
+                        <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24"
                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                 stroke-linejoin="round">
                                 <circle cx="12" cy="12" r="5"></circle>

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -146,6 +146,7 @@
                             <span class="btn-gradient-blur"></span>
                         </button>
 
+                        {# HIDDEN: OR divider + social signup buttons — stashed, uncomment to restore
                         <div class="auth-divider">
                             <span>OR</span>
                         </div>
@@ -172,6 +173,7 @@
                                 <span>Google</span>
                             </button>
                         </div>
+                        #}
                     </form>
 
                     <p class="auth-footer">Already have an account? <a href="{{ url_for('login') }}">Log In</a></p>

--- a/templates/team.html
+++ b/templates/team.html
@@ -37,14 +37,13 @@
                 <a href="{{ url_for('dashboard') }}">Dashboard</a>
                 <a href="{{ url_for('report_status') }}">Statistics</a>
                 <a href="{{ url_for('team') }}" class="active">Our Team</a>
-                <a href="{{ url_for('payment') }}">Payment</a>
                 <a href="{{ url_for('help_page') }}">Help</a>
             </nav>
             <div class="nav-auth">
                 <!-- Slider toggle -->
                 <label class="theme-switch" aria-label="Toggle theme">
                     <span class="theme-row">
-                        <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24"
+                        <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24"
                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                 stroke-linejoin="round">
                                 <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
@@ -52,7 +51,7 @@
                         <input id="theme-toggle" class="theme-switch-input" type="checkbox" role="switch"
                             aria-checked="false">
                         <span class="theme-switch-track" aria-hidden="true"></span>
-                        <span class="theme-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24"
+                        <span class="theme-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24"
                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                 stroke-linejoin="round">
                                 <circle cx="12" cy="12" r="5"></circle>


### PR DESCRIPTION
## Summary
- **Fix PDF download**: Switched from form POST to `fetch` + Blob URL so Chrome no longer aborts the download; also fixed a falsy empty-dict bug in `download_pdf()` when JSON body is present
- **Remove Payment nav link**: Stripped the Payment link from all page navbars (index, projects, login, signup, team, profile, help, blogs, language, report_status, result, base, feedback_admin)
- **Uniform SVG toggle icons**: Standardized dark/light mode toggle SVGs to 16×16 px across every template
- **Fix result page text colors**: Overrode `dashboard.css` muted-color rule so body text is white and section headings are mint on the results page
- **Hide "Publish Your Perspective"**: Stashed the submit section on blogs and projects pages in Jinja block comments for easy restoration
- **Hide GitHub/Google sign-in buttons**: Stashed OR divider + social login/signup buttons in both `login.html` and `signup.html`; fixed `auth.css` so buttons are equal-width when restored

## Test plan
- [ ] Upload a radiology report and verify PDF downloads correctly (no `ERR_ABORTED`)
- [ ] Check all pages to confirm Payment link is gone from navbar
- [ ] Toggle dark/light mode on each page and confirm icon sizes are consistent
- [ ] Visit `/result` page and confirm body text is white, headings are mint
- [ ] Visit `/login` and `/signup` — confirm no OR divider or GitHub/Google buttons appear
- [ ] Visit `/blogs` and `/projects` — confirm no "Publish Your Perspective" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)